### PR TITLE
Removed embroider-safe from ember-try scenarios, since embroider-optimized is passing already

### DIFF
--- a/.changeset/real-pants-compare.md
+++ b/.changeset/real-pants-compare.md
@@ -1,0 +1,5 @@
+---
+"test-app": patch
+---
+
+Removed embroider-safe from ember-try scenarios, since embroider-optimized is passing already

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
           - 'ember-lts-5.12'
           - 'ember-release'
           - 'ember-beta'
-          - 'embroider-safe'
           - 'embroider-optimized'
     timeout-minutes: 7
     steps:


### PR DESCRIPTION
## Description

@buschtoens and I decided to set the required status checks to the following 12:

```sh
Lint (packages/ember-codemod-ember-render-helpers-to-v1)
Lint (packages/ember-render-helpers)
Lint (test-app)

Test (packages/ember-codemod-ember-render-helpers-to-v1)
Test (packages/ember-render-helpers)
Test (test-app)

Test compatibility (ember-lts-3.28)
Test compatibility (ember-lts-4.12)
Test compatibility (ember-lts-5.12)
Test compatibility (ember-release)
Test compatibility (ember-beta)
Test compatibility (embroider-optimized)
```
