### PR TITLE
Tagged 1.0.6

### DIFF
--- a/.changeset/cold-turtles-scream.md
+++ b/.changeset/cold-turtles-scream.md
@@ -1,7 +1,0 @@
----
-"ember-codemod-ember-render-helpers-to-v1": patch
-"ember-render-helpers": patch
-"test-app": patch
----
-
-Updated dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-root",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "repository": "",
   "license": "MIT",

--- a/packages/ember-codemod-ember-render-helpers-to-v1/CHANGELOG.md
+++ b/packages/ember-codemod-ember-render-helpers-to-v1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ember-codemod-ember-render-helpers-to-v1
 
+## 1.0.5
+
+### Patch Changes
+
+- [#460](https://github.com/buschtoens/ember-render-helpers/pull/460) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/ember-codemod-ember-render-helpers-to-v1/package.json
+++ b/packages/ember-codemod-ember-render-helpers-to-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-codemod-ember-render-helpers-to-v1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Rename helpers from ember-render-helpers",
   "keywords": [
     "codemod",

--- a/packages/ember-render-helpers/CHANGELOG.md
+++ b/packages/ember-render-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ember-render-helpers
 
+## 1.0.5
+
+### Patch Changes
+
+- [#460](https://github.com/buschtoens/ember-render-helpers/pull/460) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/ember-render-helpers/package.json
+++ b/packages/ember-render-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-render-helpers",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Helpers that complement @ember/render-modifiers",
   "keywords": [
     "ember-addon",

--- a/test-app/CHANGELOG.md
+++ b/test-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # test-app
 
+## 1.0.4
+
+### Patch Changes
+
+- [#460](https://github.com/buschtoens/ember-render-helpers/pull/460) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+
 ## 1.0.3
 
 ### Patch Changes

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "Test app for ember-render-helpers",
   "keywords": [


### PR DESCRIPTION
## Background

After `ember-codemod-ember-render-helpers-to-v1@1.0.5` and `ember-render-helpers@1.0.5` are released, I'll drop support for Ember 3.28 and Node 18.
