### PR TITLE
Dropped support for Ember 3.28 and Node 18

### DIFF
--- a/.changeset/clean-heads-agree.md
+++ b/.changeset/clean-heads-agree.md
@@ -1,0 +1,7 @@
+---
+"ember-codemod-ember-render-helpers-to-v1": major
+"ember-render-helpers": major
+"test-app": patch
+---
+
+Dropped Node 18 support

--- a/.changeset/fair-beers-taste.md
+++ b/.changeset/fair-beers-taste.md
@@ -1,0 +1,6 @@
+---
+"ember-render-helpers": major
+"test-app": patch
+---
+
+Dropped Ember 3.28 support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - 'ember-lts-3.28'
           - 'ember-lts-4.12'
           - 'ember-lts-5.12'
+          - 'ember-lts-6.4'
           - 'ember-release'
           - 'ember-beta'
           - 'embroider-optimized'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           cache: 'pnpm'
           node-version: ${{ env.NODE_VERSION }}
@@ -55,13 +55,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           cache: 'pnpm'
           node-version: ${{ env.NODE_VERSION }}
@@ -86,16 +86,16 @@ jobs:
           - 'ember-release'
           - 'ember-beta'
           - 'embroider-optimized'
-    timeout-minutes: 7
+    timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           cache: 'pnpm'
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
+          - 'ember-lts-3.28'
           - 'ember-lts-4.12'
           - 'ember-lts-5.12'
           - 'ember-lts-6.4'
@@ -102,7 +103,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        if: "${{ matrix.scenario != 'ember-lts-3.28' }}"
 
       - name: Test
         run: pnpm test:ember-compatibility ${{ matrix.scenario }} --- pnpm test
+        if: "${{ matrix.scenario != 'ember-lts-3.28' }}"
         working-directory: 'test-app'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - "*"
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -147,3 +147,8 @@ export default class extends Component {
   }
 }
 ```
+
+
+## Compatibility
+
+- Node.js v20 or above

--- a/README.md
+++ b/README.md
@@ -151,4 +151,5 @@ export default class extends Component {
 
 ## Compatibility
 
+- Ember.js v4.12 or above
 - Node.js v20 or above

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "packageManager": "pnpm@10.15.1",
   "engines": {
-    "node": "18.* || >= 20",
+    "node": "20.* || >= 22",
     "pnpm": ">= 10"
   },
   "pnpm": {

--- a/packages/ember-codemod-ember-render-helpers-to-v1/README.md
+++ b/packages/ember-codemod-ember-render-helpers-to-v1/README.md
@@ -52,7 +52,7 @@ pnpm build
 
 ## Compatibility
 
-- Node.js v18 or above
+- Node.js v20 or above
 
 
 ## Contributing

--- a/packages/ember-codemod-ember-render-helpers-to-v1/package.json
+++ b/packages/ember-codemod-ember-render-helpers-to-v1/package.json
@@ -39,7 +39,7 @@
     "@ijlee2-frontend-configs/eslint-config-node": "^2.1.2",
     "@ijlee2-frontend-configs/prettier": "^2.1.1",
     "@sondr3/minitest": "^0.1.2",
-    "@tsconfig/node18": "^18.2.4",
+    "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^18.19.124",
     "@types/yargs": "^17.0.33",
@@ -49,6 +49,6 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": "18.* || >= 20"
+    "node": "20.* || >= 22"
   }
 }

--- a/packages/ember-codemod-ember-render-helpers-to-v1/tsconfig.build.json
+++ b/packages/ember-codemod-ember-render-helpers-to-v1/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@tsconfig/node18/tsconfig", "@tsconfig/strictest/tsconfig"],
+  "extends": ["@tsconfig/node20/tsconfig", "@tsconfig/strictest/tsconfig"],
   "compilerOptions": {
     "declaration": false,
     "module": "nodenext",

--- a/packages/ember-codemod-ember-render-helpers-to-v1/tsconfig.json
+++ b/packages/ember-codemod-ember-render-helpers-to-v1/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@tsconfig/node18/tsconfig", "@tsconfig/strictest/tsconfig"],
+  "extends": ["@tsconfig/node20/tsconfig", "@tsconfig/strictest/tsconfig"],
   "compilerOptions": {
     "declaration": false,
     "module": "nodenext",

--- a/packages/ember-render-helpers/README.md
+++ b/packages/ember-render-helpers/README.md
@@ -147,3 +147,8 @@ export default class extends Component {
   }
 }
 ```
+
+
+## Compatibility
+
+- Node.js v20 or above

--- a/packages/ember-render-helpers/README.md
+++ b/packages/ember-render-helpers/README.md
@@ -151,4 +151,5 @@ export default class extends Component {
 
 ## Compatibility
 
+- Ember.js v4.12 or above
 - Node.js v20 or above

--- a/packages/ember-render-helpers/package.json
+++ b/packages/ember-render-helpers/package.json
@@ -82,7 +82,7 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": "18.* || >= 20"
+    "node": "20.* || >= 22"
   },
   "ember": {
     "edition": "octane"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,9 @@ importers:
       '@sondr3/minitest':
         specifier: ^0.1.2
         version: 0.1.2
-      '@tsconfig/node18':
-        specifier: ^18.2.4
-        version: 18.2.4
+      '@tsconfig/node20':
+        specifier: ^20.1.6
+        version: 20.1.6
       '@tsconfig/strictest':
         specifier: ^2.0.5
         version: 2.0.5
@@ -1553,8 +1553,8 @@ packages:
   '@tsconfig/ember@3.0.11':
     resolution: {integrity: sha512-c9uaKBN4KxtdT/UNPPxoWghyoDsTRHzYb53Z5Fv9eum+4cok0U+hYwyKNjvCxkBjEPECS8QAyp8nGAhRifZnBQ==}
 
-  '@tsconfig/node18@18.2.4':
-    resolution: {integrity: sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==}
+  '@tsconfig/node20@20.1.6':
+    resolution: {integrity: sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==}
 
   '@tsconfig/strictest@2.0.5':
     resolution: {integrity: sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==}
@@ -8589,7 +8589,7 @@ snapshots:
 
   '@tsconfig/ember@3.0.11': {}
 
-  '@tsconfig/node18@18.2.4': {}
+  '@tsconfig/node20@20.1.6': {}
 
   '@tsconfig/strictest@2.0.5': {}
 
@@ -8629,12 +8629,12 @@ snapshots:
       '@types/ember__object': 4.0.12(@babel/core@7.28.4)
       '@types/ember__polyfills': 4.0.6
       '@types/ember__routing': 4.0.22(@babel/core@7.28.4)
-      '@types/ember__runloop': 4.0.10(@babel/core@7.28.4)
+      '@types/ember__runloop': 4.0.10
       '@types/ember__service': 4.0.9(@babel/core@7.28.4)
       '@types/ember__string': 3.0.15
       '@types/ember__template': 4.0.7
       '@types/ember__test': 4.0.6(@babel/core@7.28.4)
-      '@types/ember__utils': 4.0.7
+      '@types/ember__utils': 4.0.7(@babel/core@7.28.4)
       '@types/rsvp': 4.0.9
     optional: true
 
@@ -8748,6 +8748,11 @@ snapshots:
       - supports-color
     optional: true
 
+  '@types/ember__runloop@4.0.10':
+    dependencies:
+      '@types/ember': 4.0.11
+    optional: true
+
   '@types/ember__runloop@4.0.10(@babel/core@7.28.4)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.28.4)
@@ -8776,11 +8781,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
-
-  '@types/ember__utils@4.0.7':
-    dependencies:
-      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.28.4)':

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -6,22 +6,8 @@ module.exports = async function () {
   const { default: latestVersion } = await import('latest-version');
 
   return {
-    usePnpm: true,
+    packageManager: 'pnpm',
     scenarios: [
-      {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '2.9.4',
-            '@types/ember__test-helpers': '2.9.1',
-            '@types/ember-qunit': '6.1.1',
-            'ember-cli': '~3.28.0',
-            'ember-qunit': '6.0.0',
-            'ember-resolver': '11.0.1',
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
       {
         name: 'ember-lts-4.12',
         npm: {
@@ -35,6 +21,14 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~5.12.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-6.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~6.4.0',
           },
         },
       },
@@ -56,18 +50,6 @@ module.exports = async function () {
           },
         },
       },
-      /*
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await latestVersion('ember-source', {
-              version: 'alpha',
-            }),
-          },
-        },
-      },
-      */
       embroiderSafe(),
       embroiderOptimized(),
     ],

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.101.3"
   },
   "engines": {
-    "node": "18.* || >= 20"
+    "node": "20.* || >= 22"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## Notes

Ember 4.12 is the minimum supported version.
